### PR TITLE
css scrollSnapType를 쓰면 높이를 고정해야하므로

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -107,7 +107,7 @@ export default function Page() {
     section: CSSProperties
   } = {
     container: {
-      height: '100%',
+      height: '100vh',
       overflowY: 'scroll' as const,
       scrollSnapType: 'y mandatory' as const,
       scrollBehavior: 'smooth' as const
@@ -119,7 +119,7 @@ export default function Page() {
   };
 
   return (
-    <Box style={{ height: '100vh' }}>
+    <Box style={{ height: '100%' }}>
       <Menu
         opacity={opacity}
         title={<Typography

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,11 +45,9 @@ export default function Page() {
   }, []);
 
   return (
-    <>
+    <Box style={{ height: '100%' }}>
       <Menu title={<></>} opacity={0} />
-      <Box style={{
-        height: '100vh'
-      }}>
+      <Box style={{ height: '100vh' }}>
 
         <Box style={{ ...styles.container, backgroundColor: 'var(--primary-color-50)', }}>
 
@@ -86,6 +84,6 @@ export default function Page() {
           </Box>
         </Box>
       </Box >
-    </>
+    </Box>
   );
 }


### PR DESCRIPTION
 모바일에서 주소표시줄 삭제 동작이 되지않아서
 우선 상위 요소의 높이를 100%로해서 가능한지 테스트